### PR TITLE
Add test for maestro support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ _setupCardTypeAliases('AMERICANEXPRESS', ['ae', 'AE', 'ax', 'AX', 'amex', 'AMEX'
 _setupCardTypeAliases('DINERSCLUB', ['dinersclub']);
 _setupCardTypeAliases('DISCOVER', ['dc', 'DC', 'discover']);
 _setupCardTypeAliases('JCB', ['jcb']);
-_setupCardTypeAliases('MAESTRO', []);
+_setupCardTypeAliases('MAESTRO', ['maestro']);
 
 // Store original defaults. This must happen after aliases are setup
 const _originalDefaults = Merge({}, _defaults);

--- a/test/index.js
+++ b/test/index.js
@@ -213,6 +213,7 @@ describe('CreditCard', () => {
       expect(CreditCard.determineCardType('4111111111111111')).to.equal('VISA');
       expect(CreditCard.determineCardType('4012888888881881')).to.equal('VISA');
       expect(CreditCard.determineCardType('4222222222222')).to.equal('VISA');
+      expect(CreditCard.determineCardType('6771830999991239')).to.equal('MAESTRO');
       expect(CreditCard.determineCardType('0000000000000000')).to.equal(null);
       done();
     });
@@ -234,6 +235,8 @@ describe('CreditCard', () => {
       expect(CreditCard.determineCardType('411', {allowPartial: true})).to.equal('VISA');
       expect(CreditCard.determineCardType('4', {allowPartial: true})).to.equal('VISA');
       expect(CreditCard.determineCardType('42222222222', {allowPartial: true})).to.equal('VISA');
+      expect(CreditCard.determineCardType('6', {allowPartial: true})).to.equal('MAESTRO');
+      expect(CreditCard.determineCardType('5068', {allowPartial: true})).to.equal('MAESTRO');
       done();
     });
 
@@ -262,6 +265,7 @@ describe('CreditCard', () => {
       expect(CreditCard.isValidCardNumber('4111111111111111', 'VISA')).to.equal(true);
       expect(CreditCard.isValidCardNumber('4012888888881881', 'VISA')).to.equal(true);
       expect(CreditCard.isValidCardNumber('4222222222222', 'VISA')).to.equal(true);
+      expect(CreditCard.isValidCardNumber('6771830999991239', 'MAESTRO')).to.equal(true);
       done();
     });
 
@@ -289,6 +293,7 @@ describe('CreditCard', () => {
       expect(CreditCard.doesNumberMatchType('4111111111111111', 'VISA')).to.equal(true);
       expect(CreditCard.doesNumberMatchType('4012888888881881', 'VISA')).to.equal(true);
       expect(CreditCard.doesNumberMatchType('4222222222222', 'VISA')).to.equal(true);
+      expect(CreditCard.doesNumberMatchType('6771830999991239', 'MAESTRO')).to.equal(true);
       done();
     });
 


### PR DESCRIPTION
This adds some basic tests to check that maestro is correctly supported.

With that, we may be able to get your continuationlabs/credit-card#37 merged and a new release supporting maestro cards.

Let me know if you need something else.